### PR TITLE
Prevent page reload on empty navigation

### DIFF
--- a/src/pages/[ymd].astro
+++ b/src/pages/[ymd].astro
@@ -95,13 +95,17 @@ const title = format(parseISO(ymd), "PPPP");
   <script>
     window.addEventListener("keydown", (event) => {
       if (event.key === "ArrowLeft" && !event.metaKey) {
-        (
-          document.querySelector("[data-previous]") as HTMLAnchorElement
-        ).click();
+        const previousLink = document.querySelector("[data-previous]") as HTMLAnchorElement;
+        if (previousLink && !previousLink.classList.contains("pointer-events-none")) {
+          previousLink.click();
+        }
       }
 
       if (event.key === "ArrowRight" && !event.metaKey) {
-        (document.querySelector("[data-next]") as HTMLAnchorElement).click();
+        const nextLink = document.querySelector("[data-next]") as HTMLAnchorElement;
+        if (nextLink && !nextLink.classList.contains("pointer-events-none")) {
+          nextLink.click();
+        }
       }
 
       if (event.key === "Escape" && !event.metaKey) {

--- a/src/pages/[ymd].astro
+++ b/src/pages/[ymd].astro
@@ -37,29 +37,35 @@ const title = format(parseISO(ymd), "PPPP");
     <div class="flex items-center justify-between">
       <p class="font-bold">{title}</p>
 
-      <p class="space-x-1">
-        <a
-          href={previousYmd ? `/${previousYmd}` : `/${ymd}`}
-          data-previous
-          class:list={[
-            "inline-block font-sans font-bold",
-            previousYmd ? "text-blue-800" : "text-gray-300 pointer-events-none",
-          ]}
-        >
-          &larr;
-        </a>
+      <nav class="space-x-1">
+        {previousYmd ? (
+          <a
+            href={`/${previousYmd}`}
+            data-previous
+            class="inline-block font-sans font-bold text-blue-800"
+          >
+            &larr;
+          </a>
+        ) : (
+          <span class="inline-block font-sans font-bold text-gray-300">
+            &larr;
+          </span>
+        )}
 
-        <a
-          href={nextYmd ? `/${nextYmd}` : `/${ymd}`}
-          data-next
-          class:list={[
-            "inline-block font-sans font-bold",
-            nextYmd ? "text-blue-800" : "text-gray-300 pointer-events-none",
-          ]}
-        >
-          &rarr;
-        </a>
-      </p>
+        {nextYmd ? (
+          <a
+            href={`/${nextYmd}`}
+            data-next
+            class="inline-block font-sans font-bold text-blue-800"
+          >
+            &rarr;
+          </a>
+        ) : (
+          <span class="inline-block font-sans font-bold text-gray-300">
+            &rarr;
+          </span>
+        )}
+      </nav>
     </div>
 
     <p class="text-gray-400">#{ymds.indexOf(ymd) + 1}</p>
@@ -96,14 +102,14 @@ const title = format(parseISO(ymd), "PPPP");
     window.addEventListener("keydown", (event) => {
       if (event.key === "ArrowLeft" && !event.metaKey) {
         const previousLink = document.querySelector("[data-previous]") as HTMLAnchorElement;
-        if (previousLink && !previousLink.classList.contains("pointer-events-none")) {
+        if (previousLink) {
           previousLink.click();
         }
       }
 
       if (event.key === "ArrowRight" && !event.metaKey) {
         const nextLink = document.querySelector("[data-next]") as HTMLAnchorElement;
-        if (nextLink && !nextLink.classList.contains("pointer-events-none")) {
+        if (nextLink) {
           nextLink.click();
         }
       }


### PR DESCRIPTION
Refactor photo navigation to prevent page reload when no next/previous photo, by conditionally rendering navigation links.