### PR TITLE
Crop thumbnails to square format

### DIFF
--- a/src/components/month.astro
+++ b/src/components/month.astro
@@ -43,8 +43,8 @@ const title = format(date, "MMMM yyyy");
         if (photo.extension === "mov") {
           return (
             <Square ymd={ymd}>
-              <a href={`/${ymd}`}>
-                <div class="flex items-center justify-center h-full bg-gray-300">
+              <a href={`/${ymd}`} class="block w-full h-full">
+                <div class="flex items-center justify-center w-full h-full bg-gray-300">
                   <div class="text-3xl">▶</div>
                 </div>
               </a>
@@ -54,14 +54,12 @@ const title = format(date, "MMMM yyyy");
 
         return (
           <Square ymd={ymd}>
-            <a href={`/${ymd}`}>
+            <a href={`/${ymd}`} class="block w-full h-full">
               <Image
                 src={getPhotoFiles()[photo.filename]()}
                 format="jpg"
                 alt=""
-                width={200}
-                height={200}
-                class="aspect-square object-cover"
+                class="w-full h-full aspect-square object-cover"
               />
             </a>
           </Square>

--- a/src/components/month.astro
+++ b/src/components/month.astro
@@ -62,8 +62,6 @@ const title = format(date, "MMMM yyyy");
                 width={200}
                 height={200}
                 fit="cover"
-                position="center"
-                class="w-full h-full"
               />
             </a>
           </Square>

--- a/src/components/month.astro
+++ b/src/components/month.astro
@@ -54,7 +54,7 @@ const title = format(date, "MMMM yyyy");
 
         return (
           <Square ymd={ymd}>
-            <a href={`/${ymd}`} class="block w-full h-full">
+            <a href={`/${ymd}`}>
               <Image
                 src={getPhotoFiles()[photo.filename]()}
                 format="jpg"

--- a/src/components/month.astro
+++ b/src/components/month.astro
@@ -59,7 +59,11 @@ const title = format(date, "MMMM yyyy");
                 src={getPhotoFiles()[photo.filename]()}
                 format="jpg"
                 alt=""
-                class="w-full h-full aspect-square object-cover"
+                width={200}
+                height={200}
+                fit="cover"
+                position="center"
+                class="w-full h-full"
               />
             </a>
           </Square>

--- a/src/components/month.astro
+++ b/src/components/month.astro
@@ -43,8 +43,8 @@ const title = format(date, "MMMM yyyy");
         if (photo.extension === "mov") {
           return (
             <Square ymd={ymd}>
-              <a href={`/${ymd}`} class="block w-full h-full">
-                <div class="flex items-center justify-center w-full h-full bg-gray-300">
+              <a href={`/${ymd}`}>
+                <div class="flex items-center justify-center h-full bg-gray-300">
                   <div class="text-3xl">▶</div>
                 </div>
               </a>


### PR DESCRIPTION
Crop photo thumbnails to square format by leveraging Astro's image processing capabilities.

The previous implementation used CSS (`aspect-square object-cover`) which only visually cropped the rectangular images within a square container. This PR modifies the `Image` component to explicitly set `fit="cover"`, ensuring the actual image files are processed and cropped to a square format during the build.